### PR TITLE
Add PCM 0xff to 0xfe conversion function.

### DIFF
--- a/tgbios/SND.H
+++ b/tgbios/SND.H
@@ -44,9 +44,9 @@ struct SND_Work
 #define PCM_BANK_SIZE 4096
 #define PCM_LOOP_STOP_CODE 0xFF
 
-// During Tsugaru development, PCM native frequency was calculated as 20725Hz.
+// The master clock of the RF5C68 in FM TOWNS is 8 MHz, and dividing it by 384 gives 20833 Hz.
 // But, from TOWNS app point of view, it may be 20000Hz.
-#define PCM_NATIVE_FREQUENCY 20725
+#define PCM_NATIVE_FREQUENCY 20833
 
 #define FM_NUM_INSTRUMENTS 128
 #define PCM_NUM_INSTRUMENTS 32


### PR DESCRIPTION
When tested, both PCM instrument and voice modes convert 0xff data to 0xfe.